### PR TITLE
Re-enable scoverage 1.0.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -38,8 +38,14 @@ libraryDependencies ++= Seq(
   "org.scalastyle"        % "scalastyle_2.11"       % "0.6.0"       % "test"
 )
 
+ScoverageSbtPlugin.ScoverageKeys.coverageMinimum := 70
 
+ScoverageSbtPlugin.ScoverageKeys.coverageFailOnMinimum := false
 
+ScoverageSbtPlugin.ScoverageKeys.coverageHighlighting := {
+  if (scalaBinaryVersion.value == "2.11.4") true
+  else false
+}
 
 publishArtifact in Test := false
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -26,4 +26,5 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-license-report" % "1.0.0")
 
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.1.7")
 
-//addSbtPlugin("org.scoverage" % "scalac-scoverage-plugin" % "1.0.1")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.0.1")
+


### PR DESCRIPTION
Minor fix to re-enable scoverage with the appropriate build keys. Please try it out and merge if it works in your env as well.
